### PR TITLE
ignore bad channels + add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #### Application specific
 /config.yaml
 /config.yml
-*.m3u
+/*.m3u
 
 
 # Created by .ignore support plugin (hsz.mobi)

--- a/config/config.go
+++ b/config/config.go
@@ -23,9 +23,10 @@ type Core struct {
 }
 
 type Provider struct {
-	Uri     string
-	Filters []string
-	Setters []*Setter
+	Uri               string
+	IgnoreParseErrors bool `yaml:"ignore_parse_errors"`
+	Filters           []string
+	Setters           []*Setter
 }
 
 type Setter struct {

--- a/m3u/filter.go
+++ b/m3u/filter.go
@@ -16,5 +16,5 @@ func shouldIncludeSegment(segment *Stream, filters []string) bool {
 		}
 	}
 
-	return false
+	return len(filters) == 0
 }

--- a/m3u/m3u.go
+++ b/m3u/m3u.go
@@ -42,15 +42,15 @@ type Stream struct {
 	Uri      string
 
 	// these are attributes
-	ChNo    string
-	Id      string
-	TvgName string
-	Shift   string
-	Logo    string
-	Group   string
+	ChNo    string `yaml:"chno"`
+	Id      string `yaml:"tvg-id"`
+	TvgName string `yaml:"tvg-name"`
+	Shift   string `yaml:"tvg-shift"`
+	Logo    string `yaml:"tvg-logo"`
+	Group   string `yaml:"group-title"`
 }
 
-func decode(reader io.Reader, providerConfig *config.Provider) (Streams, error) {
+func decode(conf *config.Config, reader io.Reader, providerConfig *config.Provider) (Streams, error) {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(reader)
 	if err != nil {
@@ -58,7 +58,7 @@ func decode(reader io.Reader, providerConfig *config.Provider) (Streams, error) 
 		return nil, err
 	}
 
-	groupOrder = config.Get().GetGroupOrder()
+	groupOrder = conf.GetGroupOrder()
 
 	var eof bool
 	streams := Streams{}
@@ -84,6 +84,9 @@ func decode(reader io.Reader, providerConfig *config.Provider) (Streams, error) 
 		lines++
 		stream, err := parseExtinfLine(extinfLine, urlLine)
 		if err != nil {
+			if providerConfig.IgnoreParseErrors {
+				continue
+			}
 			return nil, err
 		}
 

--- a/m3u/process.go
+++ b/m3u/process.go
@@ -35,7 +35,7 @@ func GetPlaylist(conf *config.Config) (streams Streams, allFailed bool) {
 			}
 		}()
 
-		pl, err := decode(bufio.NewReader(resp.Body), provider)
+		pl, err := decode(conf, bufio.NewReader(resp.Body), provider)
 		if err != nil {
 			errors++
 			log.Errorf("could not decode playlist from provider %s, err = %v", provider.Uri, err)

--- a/m3u/testdata/testing/pass.m3u
+++ b/m3u/testdata/testing/pass.m3u
@@ -1,0 +1,11 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="bbc1.uk" tvg-name="BBC One" tvg-logo="http://x.y/smt" group-title="Group",BBC One
+http://url.com/1
+#EXTINF:-1 tvg-id="channel4.uk" tvg-name="Channel 4" tvg-logo="http://imgur.com/channel4.uk" group-title="Group2",Channel 4
+http://url.com/2
+#EXTINF:-1 tvg-name="Channel 3" group-title="Group4",Channel 3
+http://url.com/3
+#EXTINF:-1,Channel 3
+http://url.com/4
+#EXTINF:-1 tvg-name="overwritten tvg-name",Overwrite tvg-name
+http://url.com/5

--- a/m3u/testdata/testing/pass.yaml
+++ b/m3u/testdata/testing/pass.yaml
@@ -1,0 +1,34 @@
+provider:
+  uri: string
+  ignore_parse_errors: false
+  filters: []
+  setters: []
+
+expected_error: "__no_error__"
+streams:
+  - duration: "-1"
+    name: "BBC One"
+    uri: "http://url.com/1"
+    tvg-id: "bbc1.uk"
+    tvg-name: "BBC One"
+    tvg-logo: "http://x.y/smt"
+    group-title: "Group"
+  - duration: "-1"
+    name: "Channel 4"
+    uri: "http://url.com/2"
+    tvg-id: "channel4.uk"
+    tvg-name: "Channel 4"
+    tvg-logo: "http://imgur.com/channel4.uk"
+    group-title: "Group2"
+  - duration: "-1"
+    name: "Channel 3"
+    uri: "http://url.com/3"
+    tvg-name: "Channel 3"
+    group-title: "Group4"
+  - duration: "-1"
+    name: "Channel 3"
+    uri: "http://url.com/4"
+  - duration: "-1"
+    name: "Overwrite tvg-name"
+    uri: "http://url.com/5"
+    tvg-name: "overwritten tvg-name"

--- a/m3u/testdata/testing/pass_ignore_parse_errors.m3u
+++ b/m3u/testdata/testing/pass_ignore_parse_errors.m3u
@@ -1,0 +1,9 @@
+#EXTM3U
+#EXTINF:-1,Channel 1
+http://url.com/1
+#EXTINF:-1 tvg-name="failing"item",title
+http://url.com/2
+#EXTINF:-1 tvg-id="overwr"itten",title
+http://url.com/3
+#EXTINF:-1,Channel 4
+http://url.com/4

--- a/m3u/testdata/testing/pass_ignore_parse_errors.yaml
+++ b/m3u/testdata/testing/pass_ignore_parse_errors.yaml
@@ -1,0 +1,14 @@
+provider:
+  uri: string
+  ignore_parse_errors: true
+  filters: []
+  setters: []
+
+expected_error: "__no_error__"
+streams:
+  - duration: "-1"
+    name: "Channel 1"
+    uri: "http://url.com/1"
+  - duration: "-1"
+    name: "Channel 4"
+    uri: "http://url.com/4"


### PR DESCRIPTION
This adds a feature to ignore bad channels, and also adds a basic testing framework that allows to run tests around the decoder. More tests to be added later

This fixes #6