### PR TITLE
Add a unique id based on the Uri (CUID)

### DIFF
--- a/writer/csv.go
+++ b/writer/csv.go
@@ -9,7 +9,6 @@ import (
 var csvHeaders = []string{
 	"tvg-id",
 	"group-title",
-	"group-title",
 	"tvg-name",
 	"duration",
 	"tvg-logo",

--- a/writer/m3u.go
+++ b/writer/m3u.go
@@ -1,12 +1,12 @@
 package writer
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"github.com/hoshsadiq/m3ufilter/m3u"
 	"io"
 	"strconv"
 	"strings"
-	"crypto/md5"
-	"encoding/hex"
 )
 
 func writeM3U(w io.Writer, streams []*m3u.Stream) {
@@ -25,9 +25,9 @@ func writeM3U(w io.Writer, streams []*m3u.Stream) {
 }
 
 func GetMD5Hash(text string) string {
-    hasher := md5.New()
-    hasher.Write([]byte(text))
-    return hex.EncodeToString(hasher.Sum(nil))
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func getStreamExtinf(stream *m3u.Stream) []byte {

--- a/writer/m3u.go
+++ b/writer/m3u.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"crypto/md5"
+	"encoding/hex"
 )
 
 func writeM3U(w io.Writer, streams []*m3u.Stream) {
@@ -22,6 +24,12 @@ func writeM3U(w io.Writer, streams []*m3u.Stream) {
 	}
 }
 
+func GetMD5Hash(text string) string {
+    hasher := md5.New()
+    hasher.Write([]byte(text))
+    return hex.EncodeToString(hasher.Sum(nil))
+}
+
 func getStreamExtinf(stream *m3u.Stream) []byte {
 	b := &strings.Builder{}
 	b.WriteString("\n")
@@ -32,6 +40,7 @@ func getStreamExtinf(stream *m3u.Stream) []byte {
 		writeKV(b, "tvg-chno", stream.ChNo)
 	}
 
+	writeKV(b, "CUID", GetMD5Hash(stream.Uri))
 	writeKV(b, "tvg-id", stream.Id)
 	writeKV(b, "tvg-name", stream.Name)
 	writeKV(b, "group-title", stream.Group)


### PR DESCRIPTION
CUID is a way to specify a unique id. It is useful if you are using a proxy like xteve for the m3u streams and by setting the CUID to a hash of the url, helps keep the lineup in sync even if the providers change descriptions and such for the same stream.

See the Unique ID here:
https://github.com/xteve-project/xTeVe-Documentation/blob/master/en/configuration.md#playlist

Issue - https://github.com/hoshsadiq/m3ufilter/issues/10